### PR TITLE
chore: fixing action button wrapping

### DIFF
--- a/response-body-view.js
+++ b/response-body-view.js
@@ -81,10 +81,16 @@ export class ResponseBodyView extends LitElement {
     .content-actions {
       display: flex;
       flex-direction: row;
+      flex-wrap: wrap;
       align-items: center;
       margin-bottom: 8px;
     }
 
+    .action-button {
+      margin-top: 5px;
+      white-space: nowrap;
+    }
+    
     .download-link {
       text-decoration: none;
       color: inherit;

--- a/response-body-view.js
+++ b/response-body-view.js
@@ -87,7 +87,7 @@ export class ResponseBodyView extends LitElement {
     }
 
     .action-button {
-      margin-top: 5px;
+      margin-top: 4px;
       white-space: nowrap;
     }
     


### PR DESCRIPTION
This PR fixes some styling issues with the content action buttons' wrapping.
Before:
![image](https://user-images.githubusercontent.com/24916481/68497807-2aedbd80-0234-11ea-954a-bf4a5c177b77.png)
![image](https://user-images.githubusercontent.com/24916481/68497815-2de8ae00-0234-11ea-8b0e-cb59b7170f52.png)

After:
![image](https://user-images.githubusercontent.com/24916481/68497823-317c3500-0234-11ea-93b6-837f447f00c6.png)
![image](https://user-images.githubusercontent.com/24916481/68497831-350fbc00-0234-11ea-8af5-6142260d4dcf.png)
